### PR TITLE
Add Node.js SQLite WBS demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+wbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# WBSManegement
+# WBS Management Demo
+
+This is a simple WBS management application built with Node.js, SQLite and vanilla HTML/JS/CSS.
+
+## Setup
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Start the server
+
+```bash
+npm start
+```
+
+The application will run on [http://localhost:3000](http://localhost:3000).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "wbs-management",
+  "version": "1.0.0",
+  "description": "Simple WBS management system",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sqlite3": "^5.1.6"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>WBS Management</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>WBS Management</h1>
+  <form id="task-form">
+    <input type="text" id="task_name" placeholder="Task Name" required>
+    <input type="text" id="major_category" placeholder="Major Category" required>
+    <input type="text" id="sub_category" placeholder="Sub Category" required>
+    <input type="text" id="assignee" placeholder="Assignee" required>
+    <input type="date" id="planned_start_date" required>
+    <input type="date" id="planned_end_date" required>
+    <select id="status">
+      <option value="未着手">未着手</option>
+      <option value="進行中">進行中</option>
+      <option value="遅延">遅延</option>
+      <option value="完了">完了</option>
+      <option value="保留">保留</option>
+    </select>
+    <button type="submit">Add Task</button>
+  </form>
+  <table id="tasks">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Name</th>
+        <th>Assignee</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+<script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,49 @@
+async function loadTasks() {
+  const res = await fetch('/tasks');
+  const tasks = await res.json();
+  const tbody = document.querySelector('#tasks tbody');
+  tbody.innerHTML = '';
+  tasks.forEach(t => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${t.task_id}</td>
+      <td>${t.task_name}</td>
+      <td>${t.assignee}</td>
+      <td>${t.status}</td>
+      <td><button data-id="${t.task_id}">Delete</button></td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+async function addTask(e) {
+  e.preventDefault();
+  const data = {
+    task_name: document.getElementById('task_name').value,
+    major_category: document.getElementById('major_category').value,
+    sub_category: document.getElementById('sub_category').value,
+    assignee: document.getElementById('assignee').value,
+    planned_start_date: document.getElementById('planned_start_date').value,
+    planned_end_date: document.getElementById('planned_end_date').value,
+    status: document.getElementById('status').value
+  };
+  await fetch('/tasks', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(data)
+  });
+  e.target.reset();
+  loadTasks();
+}
+
+document.getElementById('task-form').addEventListener('submit', addTask);
+
+document.querySelector('#tasks tbody').addEventListener('click', async e => {
+  if (e.target.tagName === 'BUTTON') {
+    const id = e.target.dataset.id;
+    await fetch('/tasks/' + id, {method: 'DELETE'});
+    loadTasks();
+  }
+});
+
+loadTasks();

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,19 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+form input, form select {
+  margin-right: 5px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 20px;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 5px 8px;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,88 @@
+const express = require('express');
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+
+const app = express();
+const dbFile = path.join(__dirname, 'wbs.db');
+const db = new sqlite3.Database(dbFile);
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+// Initialize database
+const initSql = `CREATE TABLE IF NOT EXISTS tasks (
+  task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_name TEXT NOT NULL,
+  major_category TEXT NOT NULL,
+  sub_category TEXT NOT NULL,
+  assignee TEXT NOT NULL,
+  planned_start_date TEXT NOT NULL,
+  planned_end_date TEXT NOT NULL,
+  actual_start_date TEXT,
+  actual_end_date TEXT,
+  progress_percent INTEGER DEFAULT 0,
+  status TEXT NOT NULL
+);`;
+
+db.serialize(() => {
+  db.run(initSql);
+});
+
+// Get all tasks
+app.get('/tasks', (req, res) => {
+  db.all('SELECT * FROM tasks ORDER BY task_id', (err, rows) => {
+    if (err) return res.status(500).json({error: err.message});
+    res.json(rows);
+  });
+});
+
+// Create task
+app.post('/tasks', (req, res) => {
+  const t = req.body;
+  const sql = `INSERT INTO tasks (task_name, major_category, sub_category, assignee, planned_start_date, planned_end_date, actual_start_date, actual_end_date, progress_percent, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+  const params = [t.task_name, t.major_category, t.sub_category, t.assignee, t.planned_start_date, t.planned_end_date, t.actual_start_date || null, t.actual_end_date || null, t.progress_percent || 0, t.status];
+  db.run(sql, params, function(err){
+    if (err) return res.status(500).json({error: err.message});
+    db.get('SELECT * FROM tasks WHERE task_id = ?', [this.lastID], (err, row) => {
+      if (err) return res.status(500).json({error: err.message});
+      res.status(201).json(row);
+    });
+  });
+});
+
+// Update task
+app.patch('/tasks/:id', (req, res) => {
+  const id = req.params.id;
+  const fields = ['task_name','major_category','sub_category','assignee','planned_start_date','planned_end_date','actual_start_date','actual_end_date','progress_percent','status'];
+  const updates = [];
+  const params = [];
+
+  fields.forEach(f => {
+    if (req.body[f] !== undefined) {
+      updates.push(`${f} = ?`);
+      params.push(req.body[f]);
+    }
+  });
+  if (updates.length === 0) return res.status(400).json({error: 'No fields to update'});
+  params.push(id);
+  const sql = `UPDATE tasks SET ${updates.join(', ')} WHERE task_id = ?`;
+  db.run(sql, params, function(err){
+    if (err) return res.status(500).json({error: err.message});
+    db.get('SELECT * FROM tasks WHERE task_id = ?', [id], (err, row) => {
+      if (err) return res.status(500).json({error: err.message});
+      res.json(row);
+    });
+  });
+});
+
+// Delete task
+app.delete('/tasks/:id', (req, res) => {
+  const id = req.params.id;
+  db.run('DELETE FROM tasks WHERE task_id = ?', [id], function(err){
+    if (err) return res.status(500).json({error: err.message});
+    res.json({deleted: this.changes});
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));


### PR DESCRIPTION
## Summary
- set up Node.js project with Express and SQLite
- add basic REST API for tasks
- create simple HTML/JS/CSS frontend for task list
- document setup instructions

## Testing
- `npm install`
- `npm start` (server runs)


------
https://chatgpt.com/codex/tasks/task_e_684576359914832a905c31d011739155