### PR TITLE
Use stored token for Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,11 @@ Use the following endpoints to manage users and tokens:
 * `POST /auth/logout` – revoke a refresh token.
 
 Include the access token as a Bearer token in the `Authorization` header when modifying tasks.
+
+After registering or logging in, store the returned `accessToken` in the browser using:
+
+```javascript
+localStorage.setItem('accessToken', '<token>');
+```
+
+Once saved, load the UI (open `index.html`) and the application will automatically send the token in the `Authorization` header for task operations.

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -47,9 +47,13 @@ function App() {
       planned_end_date: f.planned_end_date.value,
       status: f.status.value
     };
+    const token = localStorage.getItem('accessToken');
     await fetch('/tasks', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer dummy' },
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
       body: JSON.stringify(payload)
     });
     f.reset();


### PR DESCRIPTION
## Summary
- pull auth token from `localStorage` when sending task creation requests
- clarify how to store the token in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68457f1fc5e0832a897e3ec87d829b0d