### PR TITLE
Improve task form error handling

### DIFF
--- a/public/app.jsx
+++ b/public/app.jsx
@@ -48,7 +48,11 @@ function App() {
       status: f.status.value
     };
     const token = localStorage.getItem('accessToken');
-    await fetch('/tasks', {
+    if (!token) {
+      alert('Please log in first');
+      return;
+    }
+    const res = await fetch('/tasks', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -56,6 +60,15 @@ function App() {
       },
       body: JSON.stringify(payload)
     });
+    if (!res.ok) {
+      try {
+        const err = await res.json();
+        alert(err.error || 'Failed to add task');
+      } catch (e) {
+        alert('Failed to add task');
+      }
+      return;
+    }
     f.reset();
   };
 


### PR DESCRIPTION
## Summary
- show login alert if token missing
- alert and stop on server error responses
- only reset form on success

## Testing
- `npm test`
- Manual: start server and POST /tasks without token to get Unauthorized, then with token to create a task

------
https://chatgpt.com/codex/tasks/task_e_684585093f38832a99153047e8caabec