### PR TITLE
Fix gantt date sync when actual dates are strings

### DIFF
--- a/public/app.jsx
+++ b/public/app.jsx
@@ -127,8 +127,8 @@ function WBSPage() {
       assignee: t.assignee,
       planned_start_date: t.planned_start_date,
       planned_end_date: t.planned_end_date,
-      actual_start_date: t.actual_start_date,
-      actual_end_date: t.actual_end_date
+      actual_start_date: t.actual_start_date ? new Date(t.actual_start_date) : null,
+      actual_end_date: t.actual_end_date ? new Date(t.actual_end_date) : null
     }));
     const linkData = links.map(l => ({
       id: l.link_id,


### PR DESCRIPTION
## Summary
- convert actual start/end date strings to Date objects on load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845a09804e0832abb644fbe4cdb91c2